### PR TITLE
avoid warnings during initialization if $SIG{__DIE__} set

### DIFF
--- a/lib/Net/Server.pm
+++ b/lib/Net/Server.pm
@@ -88,7 +88,7 @@ sub _initialize {
     my $self = shift;
     my $prop = $self->{'server'} ||= {};
 
-    $self->commandline($self->_get_commandline) if ! eval { $self->commandline }; # save for a HUP
+    $self->commandline($self->_get_commandline) if ! eval { local $SIG{__DIE__}; $self->commandline }; # save for a HUP
     $self->configure_hook;      # user customizable hook
     $self->configure;           # allow for reading of commandline, program, and configuration file parameters
 


### PR DESCRIPTION
Fix warnings if $SIG{**DIE**} set.
Fix  https://github.com/miyagawa/Starman/issues/54
