### PR TITLE
Replace the use of POSIX::tmpnam with File::Temp::tmpnam

### DIFF
--- a/examples/connection_test.pl
+++ b/examples/connection_test.pl
@@ -34,7 +34,7 @@ use strict;
 use warnings;
 use base qw(Net::Server);
 use IO::Socket ();
-use POSIX qw(tmpnam);
+use File::Temp ();
 use Socket qw(SOCK_DGRAM SOCK_STREAM);
 
 sub post_bind_hook {
@@ -44,7 +44,7 @@ sub post_bind_hook {
   }
 }
 
-my $socket_file  = tmpnam();
+my $socket_file  = File::Temp::tmpnam();
 $socket_file =~ s|/[^/]+$|/mysocket.file|;
 my $socket_file2 = $socket_file ."2";
 my $udp_port    = 20204;

--- a/lib/Net/Server/PreForkSimple.pm
+++ b/lib/Net/Server/PreForkSimple.pm
@@ -25,6 +25,7 @@ use strict;
 use base qw(Net::Server);
 use Net::Server::SIG qw(register_sig check_sigs);
 use POSIX qw(WNOHANG EINTR);
+use File::Temp ();
 use Fcntl ();
 
 sub net_server_type { __PACKAGE__ }
@@ -81,7 +82,7 @@ sub post_bind {
         if (defined $prop->{'lock_file'}) {
             $prop->{'lock_file_unlink'} = undef;
         } else {
-            $prop->{'lock_file'} = eval { require File::Temp } ? File::Temp::tmpnam() : POSIX::tmpnam();
+            $prop->{'lock_file'} = File::Temp::tmpnam();
             $prop->{'lock_file_unlink'} = 1;
         }
 
@@ -407,7 +408,7 @@ parameters.
     serialize         (flock|semaphore
                        |pipe|none)  undef
     # serialize defaults to flock on multi_port or on Solaris
-    lock_file         "filename"              File::Temp::tempfile or POSIX::tmpnam
+    lock_file         "filename"              File::Temp::tempfile
 
     check_for_dead    \d+                     30
 

--- a/t/UNIX_test.t
+++ b/t/UNIX_test.t
@@ -2,7 +2,7 @@
 
 package Net::Server::Test;
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp ();
 use English qw($UID $GID);
 use FindBin qw($Bin);
 use lib $Bin;
@@ -22,7 +22,7 @@ sub accept {
     return shift->SUPER::accept(@_);
 }
 
-my $socket_file = tmpnam; # must do before fork
+my $socket_file = File::Temp::tmpnam();
 my $ok = eval {
     local $SIG{'ALRM'} = sub { die "Timeout\n" };
     alarm $env->{'timeout'};


### PR DESCRIPTION
RT 105512: This POSIX::tmpnam has been deprecated in perl 5.22
