### PR TITLE
Use File::Temp instead of POSIX::tmpnam

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,7 @@ my %WriteMakefileArgs = (
   "LICENSE" => "perl",
   "NAME" => "Net::Server",
   "PREREQ_PM" => {
+    "File::Temp" => 0,
     "IO::Socket" => 0,
     "POSIX" => 0,
     "Socket" => 0,

--- a/examples/connection_test.pl
+++ b/examples/connection_test.pl
@@ -20,11 +20,11 @@ connection_test.pl - Test UDP/TCP/UNIX/UNIX_DGRAM connections
 
     # or
 
-    perl connection_test.pl UNIX
+    perl connection_test.pl UNIX <UNIX socket directory>
 
     # or
 
-    perl connection_test.pl UNIX_DGRAM
+    perl connection_test.pl UNIX_DGRAM <UNIX socket directory>
 
 =cut
 
@@ -34,7 +34,8 @@ use strict;
 use warnings;
 use base qw(Net::Server);
 use IO::Socket ();
-use POSIX qw(tmpnam);
+use File::Temp qw(tempdir);
+use File::Spec::Functions qw(catdir);
 use Socket qw(SOCK_DGRAM SOCK_STREAM);
 
 sub post_bind_hook {
@@ -44,13 +45,14 @@ sub post_bind_hook {
   }
 }
 
-my $socket_file  = tmpnam();
-$socket_file =~ s|/[^/]+$|/mysocket.file|;
-my $socket_file2 = $socket_file ."2";
+my $socket_dir  = $ARGV[1] || tempdir(CLEANUP => 1);
+my $socket_file = catdir($socket_dir, 'mysocket.file');
+my $socket_file2 = catdir($socket_dir, 'mysocket.file2');
 my $udp_port    = 20204;
 my $tcp_port    = 20204;
 
 print "\$Net::Server::VERSION = $Net::Server::VERSION\n";
+print "UNIX socket directory = $socket_dir\n";
 
 if( @ARGV ){
   if( uc($ARGV[0]) eq 'UDP' ){

--- a/lib/Net/Server/PreFork.pm
+++ b/lib/Net/Server/PreFork.pm
@@ -512,7 +512,7 @@ You really should also see L<Net::Server::PreForkSimple>.
     serialize           (flock|semaphore
                          |pipe|none)            undef
     # serialize defaults to flock on multi_port or on Solaris
-    lock_file           "filename"              File::Temp::tempfile or POSIX::tmpnam
+    lock_file           "filename"              File::Temp->new
 
     check_for_dead      \d+                     30
     check_for_waiting   \d+                     10

--- a/t/UNIX_test.t
+++ b/t/UNIX_test.t
@@ -2,7 +2,8 @@
 
 package Net::Server::Test;
 use strict;
-use POSIX qw(tmpnam);
+use File::Temp qw(tempdir);
+use File::Spec::Functions qw(catfile);
 use English qw($UID $GID);
 use FindBin qw($Bin);
 use lib $Bin;
@@ -22,7 +23,8 @@ sub accept {
     return shift->SUPER::accept(@_);
 }
 
-my $socket_file = tmpnam; # must do before fork
+my $socket_dir = tempdir(CLEANUP => 1);
+my $socket_file = catfile($socket_dir, 'socket'); # must do before fork
 my $ok = eval {
     local $SIG{'ALRM'} = sub { die "Timeout\n" };
     alarm $env->{'timeout'};


### PR DESCRIPTION
POSIX::tmpnam is insecure, and has been removed in Perl 5.26.

* Use File::Temp::tempfile for lock file
* Use File::Temp::tempdir in UNIX socket test/example
