### PR TITLE
Set NS_port on UNIX client sockets

### DIFF
--- a/lib/Net/Server/Proto/UNIX.pm
+++ b/lib/Net/Server/Proto/UNIX.pm
@@ -80,6 +80,20 @@ sub reconnect { # connect on a sig -HUP
     $sock->fdopen($fd, 'w') or $server->fatal("Error opening to file descriptor ($fd) [$!]");
 }
 
+sub accept {
+    my ($sock, $class) = (@_);
+    my ($client, $peername);
+    if (wantarray) {
+        ($client, $peername) = $sock->SUPER::accept($class);
+    } else {
+        $client = $sock->SUPER::accept($class);
+    }
+    if (defined $client) {
+        $client->NS_port($sock->NS_port);
+    }
+    return wantarray ? ($client, $peername) : $client;
+}
+
 # a string containing any information necessary for restarting the server
 # via a -HUP signal
 # a newline is not allowed

--- a/t/UNIX_test.t
+++ b/t/UNIX_test.t
@@ -25,6 +25,18 @@ sub accept {
 
 my $socket_dir = tempdir(CLEANUP => 1);
 my $socket_file = catfile($socket_dir, 'socket'); # must do before fork
+
+sub allow_deny_hook {
+    my ($server, $client) = @_;
+
+    ### check the properties of the client socket
+    if($client->NS_proto eq 'UNIX') {
+        return $client->NS_port eq $socket_file;
+    } else {
+        return $client->NS_port == $env->{'ports'}->[0];
+    }
+}
+
 my $ok = eval {
     local $SIG{'ALRM'} = sub { die "Timeout\n" };
     alarm $env->{'timeout'};


### PR DESCRIPTION
This patch populates the NS_port property on client Proto::UNIX sockets, by copying the value from the server socket on accept, which is the same behavior as the INET sockets.

amavisd-new uses the NS_port value to distinguish which socket has accepted a connection to apply a per-socket configuration such as the network ACL and the protocol. This feature is broken for UNIX domain sockets now. I'm not sure, but it worked with some old version of Net::Server.

ref:
- https://rt.cpan.org/Public/Bug/Display.html?id=117422
- https://lists.amavis.org/pipermail/amavis-users/2015-April/003549.html