### PR TITLE
Add SSL_verify_callback to @ssl_args

### DIFF
--- a/lib/Net/Server/Proto/SSL.pm
+++ b/lib/Net/Server/Proto/SSL.pm
@@ -42,6 +42,7 @@ my @ssl_args = qw(
     SSL_passwd_cb
     SSL_max_getline_length
     SSL_error_callback
+    SSL_verify_callback
 );
 
 sub NS_proto { 'SSL' }


### PR DESCRIPTION
In a situation where we want to implement TOFU from the server side, accepting self-signed client certificates and storing their fingerprints, we need to tell the server to verify the peer certificates (SSL_verify_mode => SSL_VERIFY_PEER) and we need to write the verification code ourselves (SSL_verify_callback => \&verify_client_cert). Without this change, SSL_verify_mode is passed on to IO::Socket::SSL but SSL_verify_callback is not, resulting in the server verifying and rejecting our self-signed client certificates.

The reason this came up is because I'm writing a server for Gemini, and [the specification](https://gemini.circumlunar.space/docs/specification.html) says in section 4.3:

> Although rarely seen on the web, TLS permits clients to identify themselves to servers using certificates, in exactly the same way that servers traditionally identify themselves to the client. Gemini includes the ability for servers to request in-band that a client repeats a request with a client certificate.

Thus, if my server wants to allow certain actions (like editing a wiki) with a client certificate identifying a user, but also wants to people to read all the pages without a client certificate, I need more fine-grained control over when I'm going to request client certificates.