### PR TITLE
Fix spin loop in SSLEAY::print

### DIFF
--- a/lib/Net/Server/Proto/SSLEAY.pm
+++ b/lib/Net/Server/Proto/SSLEAY.pm
@@ -372,6 +372,7 @@ sub print {
     my $buf    = @_ == 1 ? $_[0] : join('', @_);
     my $ssl    = $client->SSLeay;
     while (length $buf) {
+        return 0 if ($client->eof());
         vec(my $vec = '', $client->fileno, 1) = 1;
         select(undef, $vec, undef, undef);
 


### PR DESCRIPTION
If a client becomes totally unresponsive, SSLEAY will eventually transmit a 500/server error regarding the timeout reading headers. For an unresponsive client, this will eventually time out, and the server process will spin with select returning EAGAIN/EWOULDBLOCK.

The fix is to return from 'print' if the $client filehandle is at eof.