### PR TITLE
Stop warnings in SSLEAY

### DIFF
--- a/lib/Net/Server/Proto/SSLEAY.pm
+++ b/lib/Net/Server/Proto/SSLEAY.pm
@@ -311,6 +311,7 @@ sub read_until {
 sub read {
     my ($client, $buf, $size, $offset) = @_;
     my ($ok, $read) = $client->read_until($size, undef, 1);
+    defined($_[1]) or $_[1] = '';
     substr($_[1], $offset || 0, defined($buf) ? length($buf) : 0, $read);
     return length $read;
 }


### PR DESCRIPTION
Please review my change: I'm no Perl guru:) 
I already filed some details of my problem on CPAN in https://rt.cpan.org/Ticket/Display.html?id=118312
In short, when read is called with an undef second argument (the buffer where the read data should be written into), a warning is thrown:
Use of uninitialized value $_[1] in substr at /usr/share/perl5/vendor_perl/Net/Server/Proto/SSLEAY.pm line 313, <$read> line ...

One warning for every read call, so it floods the console or log files. The warning is due to the use of substr() with 4 arguments, where substr() replaces a portion of the buffer.
The warning can also be avoided by passing read() an already initalized buffer, like the empty string. But it seems reasonable to me to pass an undef buffer, since it has to be written and not read. So I initialize the buffer to the empty string when it is undef, before passing it to substr() for filling it.