### PR TITLE
fix UDP recieving in Fork server

### DIFF
--- a/lib/Net/Server/Fork.pm
+++ b/lib/Net/Server/Fork.pm
@@ -165,7 +165,7 @@ sub accept {
     return undef if ! defined $sock;
 
     # check if this is UDP
-    if (SOCK_DGRAM == unpack('i', $sock->getsockopt(SOL_SOCKET, SO_TYPE))) {
+    if (SOCK_DGRAM == $sock->getsockopt(SOL_SOCKET, SO_TYPE)) {
         $prop->{'udp_true'} = 1;
         $prop->{'client'}   = $sock;
         $prop->{'udp_peer'} = $sock->recv($prop->{'udp_data'}, $sock->NS_recv_len, $sock->NS_recv_flags);


### PR DESCRIPTION
The return value of getsockopt should be used directly, not attempting to convert with unpack. This matches how the other server classes do.

This bug was introduced in 5a689da0852d550ab301f0994b8a7820bba157a9 which was otherwise unrelated. The intent of the change in not obvious.

Fixes RT#146575